### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,8 @@ Quick start
 
     MIDDLEWARE = [
         ...
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        ...
         'password_policies.middleware.PasswordExpirationMiddleware',
     ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ deps =
 commands =
     flake8 password_policies testproject --exclude=*/venv/,*/migrations/,*/settings.py --show-source --count
 
-[testenv:migrations]
+[testenv:checkmigrations]
 deps =
     django
 changedir =


### PR DESCRIPTION
因為有提醒PasswordExpirationMiddleware ài tī AuthenticationMiddleware後壁，所以設定範例頭前補AuthenticationMiddleware，較清楚。