### PR TITLE
更新travis yaml。

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
-dist: bionic
+branches:
+  only:
+  - main
+  - "/\\d+\\.\\d+\\.\\d+/"
+os: linux
+dist: jammy
 language: python
 python:
-- '3.8'
+- '3.10'
 install:
 - pip install tox
 script:
@@ -23,4 +28,4 @@ jobs:
       username: "__token__"
       password: ${PYPI_TOKEN}
       on:
-        branch: main
+        tags: true

--- a/password_policies/password_validation.py
+++ b/password_policies/password_validation.py
@@ -78,7 +78,7 @@ class ReusedPasswordValidator:
             return None
 
         stored_password_records = (
-            PasswordRecord.objects.filter(user=user)
+            PasswordRecord.objects.filter(user=user.id)
         )
         if not stored_password_records:
             return None
@@ -106,7 +106,7 @@ class MinimumChangeIntervalValidator:
             return None
         try:
             latest_password_record = (
-                PasswordRecord.objects.filter(user=user).latest()
+                PasswordRecord.objects.filter(user=user.id).latest()
             )
         except PasswordRecord.DoesNotExist:
             return None


### PR DESCRIPTION
有拄著
```
  File "/home/tia/git/django-password-policies-validator/.tox/test/lib/python3.10/site-packages/django/db/models/fields/related_lookups.py", line 45, in get_normalized_value
    raise ValueError("Model instances passed to related filters must be saved.")
ValueError: Model instances passed to related filters must be saved.
```
照人建議用[user.id](https://stackoverflow.com/a/77860099)處理