### PR TITLE
Bugfix：照PEP 639，license莫用字典格式，是按SPDX License List寫做"BSD-3-Clause"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A Django app to validate password complexity and prevent users fr
 readme = "README.rst"
 requires-python = ">=3.8"
 keywords = ["django", "password", "validator"]
-license = { file="LICENSE" }
+license = "BSD-3-Clause"
 classifiers = [
     "Framework :: Django",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## PR描述

PR類型：修正Bug
Issue連結：   #28 
為什麼要有這支PR： PEP要求2026/2/28之前修改license參數格式。
值得提出或注意的技術細節：
- Python Packaging User Guide, [license and license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files)

> As per PEP 639, licenses should be declared with two fields:
>    - license is an SPDX license expression consisting of one or more license identifiers.
>    - license-files is a list of license file glob patterns.

- PEP 639 – Improving License Clarity with Better Package Metadata, [SPDX license expression syntax](https://peps.python.org/pep-0639/#spdx-license-expression-syntax)
- SPDX, [SPDX License List](https://spdx.org/licenses/)

## 變更影響

無。

## 補充資訊

## Demo畫面
